### PR TITLE
display full stack trace

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ function shift ([context, ...pending]) {
           console.log('%s\x1b[31m✘\x1b[0m %s (%dms)', indent, context.label, elapsed())
           if (err.name) {
             console.log('  %s\x1b[31m%s\x1b[0m', indent, err.name, err.message)
+            console.log(err.stack.toString().split('\n').splice(1).join('\n'))
           } else {
             console.log('  %s%s', indent, err)
           }

--- a/test/stacktrace.js
+++ b/test/stacktrace.js
@@ -1,0 +1,6 @@
+const {ok} = require('assert')
+const {test} = require('..')
+
+test('shows stacktrace', function () {
+  ok(false)
+})


### PR DESCRIPTION
Displays the full stack trace, as in #23 

It shows an output like this:

![screen shot 2017-01-19 at 10 25 17 am](https://cloud.githubusercontent.com/assets/2662706/22100972/9ef1ebc2-de31-11e6-8d67-b2486e947071.png)

Let me know what you think :)