### PR TITLE
add github issue and pull request templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,16 @@
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+
+1.
+2.
+3.
+
+## Specifications
+
+- Version:
+- Platform:

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,16 +1,18 @@
-## Expected Behavior
+## expected behavior
 
 
-## Actual Behavior
+## actual behavior
 
 
-## Steps to Reproduce the Problem
+## steps to reproduce the problem
 
 1.
 2.
 3.
 
-## Specifications
+## specifications
 
-- Version:
-- Platform:
+- m.test version:
+- node version: 
+- npm version: 
+- platform:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Fixes #
+
+## Proposed Changes
+
+-
+-
+-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-Fixes #
+fixes #
 
-## Proposed Changes
+## proposed changes
 
 -
 -


### PR DESCRIPTION
I added both

- `.github/issue_template.md`
- `.github/pull_request_template.md`

as a starting point to consolidate the way issues and pull-requests are reported.